### PR TITLE
adding MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
LICENSE files was not included in the sdist that can be found in pypi. Without that file, and with the configuration set in setup.cfg, it was not possible to build bdist_wheel for this dependency
