### PR TITLE
re #22 Updating setup.py for missing test deps.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=['pyhamcrest'],
+    tests_requires=['pyhamcrest'],
+    test_suite="tests",
     zip_safe=False,
     )


### PR DESCRIPTION
Updating setup.py because tests missing dependencies. Using this way, now `python setup.py test` can be run
