### PR TITLE
Add contain_sparse_in_order matcher

### DIFF
--- a/pyshould/matchers.py
+++ b/pyshould/matchers.py
@@ -788,6 +788,7 @@ class IsSequenceContainingEveryInOrderSparse(IsSequenceContainingEvery):
         self.order_seq = None
 
     def _matches(self, sequence):
+        self.order_seq = None
         try:
             seq = list(sequence)
             if self.matcher_all.matches(seq):
@@ -815,6 +816,7 @@ class IsSequenceContainingEveryInOrderSparse(IsSequenceContainingEvery):
         description.append_text(' in this specific order')
 
 
-register(IsSequenceContainingEveryInOrderSparse, 'contain_sparse_in_order',
+register(IsSequenceContainingEveryInOrderSparse,
+         'contain_sparse', 'have_sparse', 'contain_sparse_in_order',
          'contain_in_order_sparse', 'have_every_in_order_sparse',
          'have_in_order_sparse', 'contain_every_in_order_sparse')

--- a/tests/dsl.py
+++ b/tests/dsl.py
@@ -445,6 +445,11 @@ class DslTestCase(unittest.TestCase):
                 should.eq(1)
             )
 
+        with self.assertRaises(AssertionError):
+            [1] | should.contain_sparse_in_order(
+                should.eq(1), should.be_greater_than(7)
+            )
+
         [1, 4, 3, 3, 8, 6, 2] | should.contain_sparse_in_order(
             should.eq(1), should.be_greater_than(7)
         )


### PR DESCRIPTION
Simple matcher useful to validate ordered sequences that may contain unmeaning items.
